### PR TITLE
Server in container

### DIFF
--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -6,5 +6,4 @@ COPY . /robot
 
 RUN pip3 install -r requirements.txt
 
-ENTRYPOINT ["python3"]
-CMD ["Robot.py"]
+CMD ["python3", "Robot.py"]

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -1,6 +1,6 @@
-MAINTAINER mhjsaldanha@gmail.com
-
 FROM python:3.6.5
+
+MAINTAINER "mhjsaldanha@gmail.com"
 
 WORKDIR /robot
 

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6.5
+
+WORKDIR /robot
+
+COPY . /robot
+
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT ["python3"]
+CMD ["Robot.py"]

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -1,3 +1,5 @@
+MAINTAINER mhjsaldanha@gmail.com
+
 FROM python:3.6.5
 
 WORKDIR /robot

--- a/robot/requirements.txt
+++ b/robot/requirements.txt
@@ -1,4 +1,5 @@
 bs4
+lxml
 urllib3
 psycopg2
 psycopg2-binary

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+
+MAINTAINER "gabs.oficial98@gmail.com"
+
+WORKDIR /server
+
+COPY . /server
+
+RUN apk update && apk add yarn
+
+RUN yarn install

--- a/server/README.md
+++ b/server/README.md
@@ -1,11 +1,18 @@
 # Usage
 
-## Install
+## Installation
 
-You can use _yarn_ or _yarn install_
+If you'd like to install the server out of a container can use _yarn_ or _yarn install_
 
 ```bash
 $ sudo yarn install
+```
+
+Or you can install it inside a docker container (if you don't have docker installed already, check out the [Docker Installation Guide](https://docs.docker.com/install/))
+
+
+```bash
+$ docker image build -t server .
 ```
 
 ## Connection
@@ -21,9 +28,22 @@ DATABASE='entretenibit'
 But these are not the acctual variables to use. See Documents/Tutorial for more information
 
 
-## Run
-To run in development mode use _yarn run dev_ or _yarn dev_ 
+## Running
+To run in development mode use _yarn run dev_ or _yarn dev_
 
 ```bash
-$ yarn dev 
+$ yarn dev
+```
+
+Or, if you're running it from inside of a container
+
+```bash
+$ docker container run server yarn dev
+```
+
+Or simply
+
+
+```bash
+$ docker run --detach server yarn dev
 ```


### PR DESCRIPTION
Add Dockerfile for server container and inserted usage instructions in [README.md](https://github.com/martchellop/Entretenibit/blob/server_in_container/server/README.md).

Chose [Alpine](https://hub.docker.com/_/alpine/) as a base image because of its reliability and flexibility. I thought [alpine-node](https://hub.docker.com/r/mhart/alpine-node/) wasn't a good fit because it's not and officially maintained version.



Fix #94 