### PR TITLE
Add tests for Frontend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ services:
 
 before_install:
     - docker build -t robot ./robot/
+    - docker build -t frontend ./frontend/
 
 script:
     - bash test.bash

--- a/test.bash
+++ b/test.bash
@@ -4,10 +4,10 @@
 error=0
 
 docker run --rm robot pytest
-error=$( expr $error + $? )
+error=$(( $error + $? ))
 
 docker run --rm --tty frontend yarn build | grep "Compiled successfully."
-error=$( expr $error + $? )
+error=$(( $error + $? ))
 
 # Export error in the correct variable
 exit $error

--- a/test.bash
+++ b/test.bash
@@ -1,2 +1,13 @@
 #!/bin/bash
+
+# Accumulates the number of errors
+error=0
+
 docker run --rm robot pytest
+error=$( expr $error + $? )
+
+docker run --rm --tty frontend yarn build | grep "Compiled successfully."
+error=$( expr $error + $? )
+
+# Export error in the correct variable
+exit $error

--- a/test.bash
+++ b/test.bash
@@ -25,4 +25,4 @@ fi
 echo
 
 # Export error in the correct variable
-exit $(( $robot_error + $frontend_error ))
+exit $(( robot_error + frontend_error ))

--- a/test.bash
+++ b/test.bash
@@ -1,13 +1,28 @@
 #!/bin/bash
 
-# Accumulates the number of errors
-error=0
-
 docker run --rm robot pytest
-error=$(( $error + $? ))
+robot_error=$?
 
 docker run --rm --tty frontend yarn build | grep "Compiled successfully."
-error=$(( $error + $? ))
+frontend_error=$?
+
+echo
+
+# Print some messages for helping the user to find the problem
+if [ $robot_error == 0 ]; then
+	echo "Robot passed the tests.";
+else
+	echo "Robot HAS NOT passed the tests.";
+fi
+echo
+
+if [ $frontend_error == 0 ]; then
+	echo "Frontend passed the tests.";
+else
+	echo "Frontend HAS NOT passed the tests.";
+	echo "Please, verify if the React code is having compilation errors or warnings.";
+fi
+echo
 
 # Export error in the correct variable
-exit $error
+exit $(( $robot_error + $frontend_error ))


### PR DESCRIPTION
Travis now tests whether the React code compiles, and if it compiles makes sure it doesn't throw any warning.

This pull request is a bit bothersome for the reviewers to test. I've done the following tests in a dummy pull request:

- Robot and Frontend without any failures: Travis **accepted** the pull request

- Robot failing, but Frontend without failures: Travis **blocked** the pull request with exit error 1

- Robot failing, and Frontend with compilation error: Travis **blocked** the pull request with exit error 2

Whenever a test fails, the testing script tells you (and it shows on the Travis website) which docker container failed.

Fix #121