### PR TITLE
Change to bigger link size in database

### DIFF
--- a/robot/createDB.sql
+++ b/robot/createDB.sql
@@ -10,7 +10,7 @@ CREATE TABLE event(
     title VARCHAR(150) NOT NULL,
     description TEXT NOT NULL,
     casting VARCHAR(400),
-    link VARCHAR(70) NOT NULL,
+    link VARCHAR(150) NOT NULL,
     id BIGSERIAL,
     PRIMARY KEY(link)
 );


### PR DESCRIPTION
Last week there was at least 1 event in UFSCar page that had more 70 characters (close to 112 I think).
(again) closes #116 