### PR TITLE
Add Cronjob for robot and e-mails

### DIFF
--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -9,8 +9,7 @@ COPY . /robot
 RUN pip3 install -r requirements.txt
 
 # Update and install cron
-RUN apt-get update \
-		&& apt-get -y install -qq --force-yes --no-install-recommends cron=3.0pl1-128+deb9u1 \
+RUN apt-get update && apt-get -y install -qq --force-yes --no-install-recommends cron=3.0pl1-128+deb9u1 \
 		&& apt-get clean \
 		&& rm -rf /var/lib/apt/lists/*
 

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -8,7 +8,29 @@ COPY . /robot
 
 RUN pip3 install -r requirements.txt
 
+# Update and install cron
+RUN apt-get update && apt-get -y install -qq --force-yes cron
+
+# Add crontab file in the cron directory
+ADD crontab /etc/cron.d/hello-cron
+
+# Give execution rights on the cron job
+RUN chmod 0644 /etc/cron.d/hello-cron
+
+# Create the log file to be able to run tail
+RUN touch /var/log/cron.log
+
+# In case you want to test the cronjob without running everything, just use this
+# The "-f" option will keep cron on the foreground
+#CMD ["cron", "-f"]
+
+
 # This is a slight hack to run both the command and the e-mail.
 # 	The previous command was:
 #		CMD ["python3", "Robot.py"]
-CMD ["sh", "-c", "python3 Robot.py ; python3 send_emails.py"]
+
+# This was the command before integrating with cron:
+#		CMD ["sh", "-c", "python3 Robot.py ; python3 send_emails.py"]
+
+# The new command with cron is:
+CMD ["sh", "-c", "python3 Robot.py ; python3 send_emails.py ; cron -f"]

--- a/robot/Dockerfile
+++ b/robot/Dockerfile
@@ -9,10 +9,13 @@ COPY . /robot
 RUN pip3 install -r requirements.txt
 
 # Update and install cron
-RUN apt-get update && apt-get -y install -qq --force-yes cron
+RUN apt-get update \
+		&& apt-get -y install -qq --force-yes --no-install-recommends cron=3.0pl1-128+deb9u1 \
+		&& apt-get clean \
+		&& rm -rf /var/lib/apt/lists/*
 
 # Add crontab file in the cron directory
-ADD crontab /etc/cron.d/hello-cron
+COPY crontab /etc/cron.d/hello-cron
 
 # Give execution rights on the cron job
 RUN chmod 0644 /etc/cron.d/hello-cron

--- a/robot/crontab
+++ b/robot/crontab
@@ -6,7 +6,7 @@
 
 # This runs our scraper every day at 20:00
 # The reason for being this time is to give plenty of time for the scrapper to run before sending the e-mails at midnight on sundays
- 0 22 * * * root python3 Robot.py 
+ 0 20 * * * root python3 Robot.py 
 
 # Don't remove the empty line at the end of this file. It is required to run the cron job
 

--- a/robot/crontab
+++ b/robot/crontab
@@ -1,0 +1,12 @@
+# This prints the message to the standard docker output every minute
+* * * * * root echo "hello, cron seems to be working as intended" > /proc/1/fd/1 2>/proc/1/fd/2
+
+# This runs our send-email every sunday at midnight
+0 0 * * sun root python3 send_emails.py
+
+# This runs our scraper every day at 20:00
+# The reason for being this time is to give plenty of time for the scrapper to run before sending the e-mails at midnight on sundays
+ 0 22 * * * root python3 Robot.py 
+
+# Don't remove the empty line at the end of this file. It is required to run the cron job
+


### PR DESCRIPTION
Cronjob implemented and added to the system. Closes #162 

Things I found out during the pull request: Cronjob **does not** play nicely with Docker. It could even be argued that is even goes againt's the idea of having only one process per container.

With that in mind, maybe a better idea would have been to separate the crawling from the e-mail in different containers; then  [Tasker](https://github.com/opsxcq/tasker) could have been more easily used but I could not get it to work easily with our current setup.  Also, it would require some changes to the docker-compose. I am not at all proposing these major changes to the project at this stage, just logging my conclusions from searching the subject.

In any case, the final solution was the traditional linux cronjob system. The robot's Docker file was changed, to allow installation of cronjob and creating the necessary files for logging the jobs.

The crontab file was created, describing what to run  and when to run. What the current setup means:

- **We send-email every sunday at midnight**

- **Our scraper runs every day  at 20:00.** The reason for being this time is to give plenty of time for the scrapper to run before sending the e-mails at midnight on sundays

To test everything is working correctly, I have also added the following:

- **Every minute, print to the terminal "hello, cron seems to be working as intended".** This lets us test the crontab without having to mess around with the system's time.

So to test this pull request, just run `docker-compose build && docker-compose up` after pulling. Then wait at least 2 minutes from after the robot finished sending the e-mails and check the message "hello, cron seems to be working as intended" appears in the terminal.


PS: For the final release we can/should remove the print every minute job.

